### PR TITLE
一部画面でエラー原因となったonClickのrequired解除

### DIFF
--- a/src/component/atoms/ArrowIcon.jsx
+++ b/src/component/atoms/ArrowIcon.jsx
@@ -19,7 +19,7 @@ ArrowIcon.propTypes = {
   direction: PropTypes.oneOf(["right", "left", "top", "down"]),
   alt: PropTypes.string,
   className: PropTypes.string,
-  onClick: PropTypes.func.isRequired,
+  onClick: PropTypes.func,
 };
 
 

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -28,7 +28,7 @@ function Home() {
             onClick={() => navigate("/RecipeSelection")}
           >
             <ButtonLabel className="btnText" text="1からレシピ選択" />
-            <ArrowIcon direction="right" className="arrow" />
+            <ArrowIcon direction="right" className="arrow"/>
           </ButtonBase>
 
           <ButtonBase


### PR DESCRIPTION
ArrowIconの必須props **onClick**  がHome画面のエラー発生原因となっていたため、isRequiered 削除